### PR TITLE
Fix DCB doc

### DIFF
--- a/directives/dcb.md
+++ b/directives/dcb.md
@@ -1,4 +1,4 @@
-# DBC
+# DCB
 
 ## Syntax
 ```assembly


### PR DESCRIPTION
`dcb` is documented in [`dbc.md`](/prb28/m68k-instructions-documentation/blob/master/directives/dbc.md) It should be `dcb.md`

The title is likewise incorrect. ```DBC``` should be ```DCB```