### PR TITLE
Fix DCB doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@
 |[data_c](directives/data_c.md)|Equivalent to `section data_c,data,chip`|
 |[data_f](directives/data_f.md)|Equivalent to `section data_f,data,fast`|
 |[db](directives/db.md)|Equivalent to `dc.b` for ArgAsm, BAsm, HX68, Macro68, ProAsm, etc. compatibility|
-|[dbc](directives/dbc.md)|Insert `<exp>` zero or `<fill>` bytes/words into the current section|
+|[dcb](directives/dcb.md)|Insert `<exp>` zero or `<fill>` bytes/words into the current section|
 |[dc](directives/dc.md)|Assign the integer or string constant operands into successive bytes/words of memory in the current section|
 |[dl](directives/dl.md)|Equivalent to `dc.l` for ArgAsm, BAsm, HX68, Macro68, ProAsm, etc. compatibility|
 |[dr](directives/dr.md)|Calculates `<expN> - <current pc value>` and stores it into successive bytes/words of memory in the current section|

--- a/directives/dcb.md
+++ b/directives/dcb.md
@@ -1,4 +1,4 @@
-# DBC
+# DCB
 
 ## Syntax
 ```assembly

--- a/toc.md
+++ b/toc.md
@@ -96,7 +96,7 @@
 |[data_c](directives/data_c.md)|Equivalent to `section data_c,data,chip`|
 |[data_f](directives/data_f.md)|Equivalent to `section data_f,data,fast`|
 |[db](directives/db.md)|Equivalent to `dc.b` for ArgAsm, BAsm, HX68, Macro68, ProAsm, etc. compatibility|
-|[dbc](directives/dbc.md)|Insert `<exp>` zero or `<fill>` bytes/words into the current section|
+|[dcb](directives/dcb.md)|Insert `<exp>` zero or `<fill>` bytes/words into the current section|
 |[dc](directives/dc.md)|Assign the integer or string constant operands into successive bytes/words of memory in the current section|
 |[dl](directives/dl.md)|Equivalent to `dc.l` for ArgAsm, BAsm, HX68, Macro68, ProAsm, etc. compatibility|
 |[dr](directives/dr.md)|Calculates `<expN> - <current pc value>` and stores it into successive bytes/words of memory in the current section|


### PR DESCRIPTION
`dcb` is documented in [`dbc.md`](/prb28/m68k-instructions-documentation/blob/master/directives/dbc.md) It should be `dcb.md`

The title is likewise incorrect. ```DBC``` should be ```DCB```
Also links in TOC & README are incorrect

This PR resolves this.