### PR TITLE
68000 cmpi/tst have no PC relative addressing modes

### DIFF
--- a/instructions/cmpi.md
+++ b/instructions/cmpi.md
@@ -22,6 +22,8 @@ Subtract the immediate data from the destination operand and set the condition c
 ## Destination operand addressing modes
 |Dn|An|(An)|(An)+|&#x2011;(An)|(d,An)|(d,An,Xi)|ABS.W|ABS.L|(d,PC)|(d,PC,Xn)|imm|
 |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
-|✓||✓|✓|✓|✓|✓|✓|✓|✓|✓||
+|✓||✓|✓|✓|✓|✓|✓|✓|✓[^1]|✓[^1]||
 
 *From MOTOROLA M68000 FAMILY Programmer's reference manual. Copyright 1992 by Motorola Inc./NXP. Adapted with permission.*
+
+[^1]: PC relative addressing modes are not available on the 68000.

--- a/instructions/tst.md
+++ b/instructions/tst.md
@@ -24,6 +24,8 @@ The operand is compared with zero. No result is saved, but the contents of the *
 ## Source operand addressing modes
 |Dn|An|(An)|(An)+|&#x2011;(An)|(d,An)|(d,An,Xi)|ABS.W|ABS.L|(d,PC)|(d,PC,Xn)|imm|
 |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
-|✓||✓|✓|✓|✓|✓|✓|✓|✓|✓||
+|✓||✓|✓|✓|✓|✓|✓|✓|✓[^1]|✓[^1]||
 
 *From MOTOROLA M68000 FAMILY Programmer's reference manual. Copyright 1992 by Motorola Inc./NXP. Adapted with permission.*
+
+[^1]: PC relative addressing modes are not available on the 68000.


### PR DESCRIPTION
PC relative addressing modes for CMPI and TST are not available on the 68000.

Might be worth to mention this in the documentation, but I'm not sure if this modes should be removed (since the instruction list is 68000-centric) or tagged with a footnote (like in this PR). Feel free to edit/drop this PR.